### PR TITLE
メインタイムラインのアングル切替ホットキー追加と単一表示の収まり改善

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportaglytics",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Sports video tagging and analytics application",
   "private": true,
   "packageManager": "pnpm@9.1.0",

--- a/src/features/videoPlayer/components/Player/SyncedVideo/types.ts
+++ b/src/features/videoPlayer/components/Player/SyncedVideo/types.ts
@@ -9,6 +9,7 @@ export interface SyncedVideoPlayerProps {
   syncData?: VideoSyncData;
   syncMode?: 'auto' | 'manual';
   forceUpdateKey?: number;
+  viewMode?: 'dual' | 'angle1' | 'angle2';
 }
 
 export interface PlayerState {

--- a/src/features/videoPlayer/components/Player/VideoPlayer.tsx
+++ b/src/features/videoPlayer/components/Player/VideoPlayer.tsx
@@ -11,6 +11,7 @@ interface VideoPlayerProps {
   syncData?: VideoSyncData;
   syncMode?: 'auto' | 'manual';
   forceUpdateKey?: number;
+  viewMode?: 'dual' | 'angle1' | 'angle2';
 }
 
 export const VideoPlayer = ({
@@ -22,6 +23,7 @@ export const VideoPlayer = ({
   syncData,
   syncMode = 'auto',
   forceUpdateKey = 0,
+  viewMode = 'dual',
 }: VideoPlayerProps) => {
   // currentTimeはシークバー表示用にのみ使用（Video.js自身が時刻管理）
   void currentTime;
@@ -42,6 +44,7 @@ export const VideoPlayer = ({
       syncData={syncData}
       syncMode={syncMode}
       forceUpdateKey={forceUpdateKey}
+      viewMode={viewMode}
     />
   );
 };

--- a/src/pages/VideoPlayerApp.tsx
+++ b/src/pages/VideoPlayerApp.tsx
@@ -73,6 +73,9 @@ const VideoPlayerAppContent = () => {
 
   const [statsOpen, setStatsOpen] = useState(false);
   const [statsView, setStatsView] = useState<StatsView>('possession');
+  const [viewMode, setViewMode] = useState<'dual' | 'angle1' | 'angle2'>(
+    'dual',
+  );
 
   useManualSyncSeek({ syncMode, syncData, videoList });
 
@@ -112,6 +115,7 @@ const VideoPlayerAppContent = () => {
       timelineActionRef,
       setVideoPlayBackRate,
       setIsVideoPlaying: setisVideoPlaying,
+      setViewMode,
       handleCurrentTime,
       performUndo,
       performRedo,
@@ -185,6 +189,7 @@ const VideoPlayerAppContent = () => {
         syncData={syncData}
         syncMode={syncMode}
         playerForceUpdateKey={playerForceUpdateKey}
+        viewMode={viewMode}
         timelineActionRef={timelineActionRef}
         timeline={timeline}
         selectedTimelineIdList={selectedTimelineIdList}

--- a/src/pages/settings/components/HotkeySettings.tsx
+++ b/src/pages/settings/components/HotkeySettings.tsx
@@ -42,6 +42,8 @@ const DEFAULT_HOTKEYS: HotkeyConfig[] = [
   { id: 'skip-backward-medium', label: '5秒戻る', key: 'Left' },
   { id: 'skip-backward-large', label: '10秒戻る', key: 'Shift+Left' },
   { id: 'play-pause', label: '再生/一時停止', key: 'Space' },
+  { id: 'toggle-angle1', label: 'アングル1切替', key: 'Shift+1' },
+  { id: 'toggle-angle2', label: 'アングル2切替', key: 'Shift+2' },
 ];
 
 /**

--- a/src/pages/videoPlayer/components/PlayerSurface.tsx
+++ b/src/pages/videoPlayer/components/PlayerSurface.tsx
@@ -21,6 +21,7 @@ interface PlayerSurfaceProps {
   syncData?: VideoSyncData;
   syncMode: 'auto' | 'manual';
   playerForceUpdateKey: number;
+  viewMode: 'dual' | 'angle1' | 'angle2';
 }
 
 export const PlayerSurface: React.FC<PlayerSurfaceProps> = ({
@@ -37,6 +38,7 @@ export const PlayerSurface: React.FC<PlayerSurfaceProps> = ({
   syncData,
   syncMode,
   playerForceUpdateKey,
+  viewMode,
 }) => {
   return (
     <Box
@@ -44,6 +46,8 @@ export const PlayerSurface: React.FC<PlayerSurfaceProps> = ({
         gridColumn: '1',
         gridRow: '1',
         position: 'relative',
+        height: '100%',
+        minHeight: 0,
         '&:hover .video-controls-overlay': {
           opacity: 1,
         },
@@ -53,6 +57,8 @@ export const PlayerSurface: React.FC<PlayerSurfaceProps> = ({
         sx={{
           position: 'relative',
           width: '100%',
+          height: '100%',
+          minHeight: 0,
         }}
       >
         <VideoPlayer
@@ -65,6 +71,7 @@ export const PlayerSurface: React.FC<PlayerSurfaceProps> = ({
           syncData={syncData}
           syncMode={syncMode}
           forceUpdateKey={playerForceUpdateKey}
+          viewMode={viewMode}
         />
       </Box>
 

--- a/src/pages/videoPlayer/components/VideoPlayerLayout.tsx
+++ b/src/pages/videoPlayer/components/VideoPlayerLayout.tsx
@@ -53,6 +53,7 @@ type VideoPlayerLayoutProps = Pick<
   onApplyManualSync: () => void;
   onCancelManualSync: () => void;
   onAddToPlaylist: (items: TimelineData[]) => Promise<void>;
+  viewMode: 'dual' | 'angle1' | 'angle2';
 };
 
 export const VideoPlayerLayout = ({
@@ -94,14 +95,16 @@ export const VideoPlayerLayout = ({
   onApplyManualSync,
   onCancelManualSync,
   onAddToPlaylist,
+  viewMode,
 }: VideoPlayerLayoutProps) => {
   return isFileSelected ? (
     <Box
       sx={{
         display: 'grid',
         gridTemplateColumns: '1fr',
-        gridTemplateRows: 'auto minmax(250px, 1fr)',
+        gridTemplateRows: 'minmax(0, 1fr) minmax(250px, 1fr)',
         flex: 1,
+        height: '100%',
         minHeight: 0,
       }}
     >
@@ -119,6 +122,7 @@ export const VideoPlayerLayout = ({
         syncData={syncData}
         syncMode={syncMode}
         playerForceUpdateKey={playerForceUpdateKey}
+        viewMode={viewMode}
       />
 
       {syncMode === 'manual' && (

--- a/src/pages/videoPlayer/hooks/useHotkeyBindings.ts
+++ b/src/pages/videoPlayer/hooks/useHotkeyBindings.ts
@@ -1,4 +1,5 @@
 import { useMemo, RefObject } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import type { HotkeyConfig } from '../../../types/Settings';
 import type { ActionDefinition } from '../../../types/Settings';
 import type { TimelineActionSectionHandle } from '../components/TimelineActionSection';
@@ -13,6 +14,7 @@ interface UseHotkeyBindingsParams {
   timelineActionRef: RefObject<TimelineActionSectionHandle | null>;
   setVideoPlayBackRate: (rate: number) => void;
   setIsVideoPlaying: (value: boolean) => void;
+  setViewMode: Dispatch<SetStateAction<'dual' | 'angle1' | 'angle2'>>;
   handleCurrentTime: (event: Event, time: number) => void;
   performUndo: () => void;
   performRedo: () => void;
@@ -37,6 +39,7 @@ export const useHotkeyBindings = ({
   timelineActionRef,
   setVideoPlayBackRate,
   setIsVideoPlaying,
+  setViewMode,
   handleCurrentTime,
   performUndo,
   performRedo,
@@ -76,6 +79,22 @@ export const useHotkeyBindings = ({
       'skip-backward-large': () => {
         handleCurrentTime(new Event('hotkey'), currentTime - 10);
       },
+      'toggle-angle1': () => {
+        setViewMode((prev) => {
+          if (prev === 'dual') return 'angle1';
+          if (prev === 'angle1') return 'dual';
+          if (prev === 'angle2') return 'angle1';
+          return 'angle1';
+        });
+      },
+      'toggle-angle2': () => {
+        setViewMode((prev) => {
+          if (prev === 'dual') return 'angle2';
+          if (prev === 'angle2') return 'dual';
+          if (prev === 'angle1') return 'angle2';
+          return 'angle2';
+        });
+      },
       analyze: onAnalyze,
       undo: performUndo,
       redo: performRedo,
@@ -106,6 +125,7 @@ export const useHotkeyBindings = ({
       resetSync,
       resyncAudio,
       setIsVideoPlaying,
+      setViewMode,
       setSyncMode,
       setVideoPlayBackRate,
       onAnalyze,

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -316,6 +316,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
     { id: 'skip-backward-medium', label: '5秒戻し', key: 'Left' },
     { id: 'skip-backward-large', label: '10秒戻し', key: 'Shift+Left' },
     { id: 'play-pause', label: '再生/停止', key: 'Space' },
+    { id: 'toggle-angle1', label: 'アングル1切替', key: 'Shift+1' },
+    { id: 'toggle-angle2', label: 'アングル2切替', key: 'Shift+2' },
   ],
   language: 'ja',
   overlayClip: {


### PR DESCRIPTION
# 変更点:
- タイムライン画面に viewMode を導入し Shift+1/Shift+2 で切替
- SyncedVideoPlayer に単一/デュアル表示制御を追加
- レイアウトを高さ固定にして単一表示時にウィンドウ内へ収める
- ホットキーのデフォルト設定を追加
