### PR TITLE
docs(release): sync PR-based release flow to main

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -72,12 +72,16 @@ git pull --ff-only origin develop
 # after version/changelog commit is created on develop
 git push origin develop
 
+# create and merge a GitHub PR: develop => main
+gh pr create --base main --head develop --title "Release v<version>" --body "Release v<version>"
+
+# after CI / review / branch protection passes
+gh pr merge --merge
+
 git checkout main
 git pull --ff-only origin main
-git merge --no-ff develop
-git push origin main
 
-# tag from main after develop is merged
+# tag from main after the develop => main PR is merged
 git tag v<version>
 git push origin v<version>
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,9 @@
 - `MUST`: 通常作業のブランチ `prefix` は `feature`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf` のいずれかを使う。
 - `MUST`: `release` / `hotfix` prefix は release / 緊急修正作業として明示された場合のみ使う。
 - `MUST`: 新機能ブランチの prefix は既存運用に合わせて `feature` とする。Conventional Commits の `feat` をブランチ prefix として使わない。
+- `MUST`: 通常作業は作業ブランチから `develop` への PR で統合する。
+- `MUST`: リリース時は release 準備コミットを `develop` に統合した後、`develop` から `main` への PR を作成し、PR マージ後の `main` にリリースタグを作成する。
+- `MUST`: `main` へ直接 merge / push しない。ただし緊急 hotfix で明示承認がある場合のみ例外とし、理由を PR または release note に残す。
 - `MUST`: コミットメッセージは Conventional Commits 形式の `<type>(<scope>): <subject>` または `<type>: <subject>` を使う。
 - `MUST`: コミット `type` は変更内容に合わせて `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `style`, `build`, `ci`, `revert` から選ぶ。
 - `SHOULD`: `scope` は feature / domain / tooling 名を短く指定する（例: `fix(timeline): enable duplicate action`）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- リリース時の `develop` から `main` への統合を PR 必須の手順として明文化
+
 ## [0.6.0] - 2026-06-15
 
 ### Added

--- a/docs/development.md
+++ b/docs/development.md
@@ -214,7 +214,7 @@ pnpm run report:large-files
 ```
 main         ← 本番環境（リリースタグ）
   ↑
-develop      ← 開発統合ブランチ
+develop      ← 開発統合ブランチ（リリース時は PR で main へ統合）
   ↑
 feature/* / fix/* / refactor/* ... ← 作業ブランチ
 ```
@@ -281,6 +281,16 @@ Closes #123
 3. `pnpm run lint` / `pnpm run typecheck` / `pnpm run typecheck:electron` / `pnpm run check:architecture` を通す
 4. `develop` へのプルリクエストを作成
 5. レビュー後にマージ
+
+### リリース統合
+
+1. release 準備コミット（version / CHANGELOG / 必要な docs）を `develop` に統合
+2. `develop` から `main` へのプルリクエストを作成
+3. CI / レビュー / branch protection を通して PR をマージ
+4. マージ後の `main` を pull し、その commit に `v<version>` tag を作成
+5. tag を push して release workflow を起動
+
+`main` への直接 merge / push は行いません。緊急 hotfix で明示承認がある場合のみ例外とし、理由を PR または release note に残します。
 
 ---
 

--- a/docs/homebrew-distribution.md
+++ b/docs/homebrew-distribution.md
@@ -65,23 +65,26 @@ brew install --cask sportaglytics
 vim package.json  # "version": "<version>" に変更
 ```
 
-### 2. develop へコミットして main へマージ
+### 2. develop へコミットして main へ PR で統合
 
 ```bash
 git add package.json CHANGELOG.md
 git commit -m "chore: bump version to <version>"
 git push origin develop
 
+gh pr create --base main --head develop --title "Release v<version>" --body "Release v<version>"
+
+# CI / レビュー / branch protection 通過後
+gh pr merge --merge
+
 git checkout main
 git pull --ff-only origin main
-git merge --no-ff develop
-git push origin main
 ```
 
 ### 3. タグプッシュ
 
 ```bash
-# タグをプッシュ（これで自動化開始！）
+# main の PR merge commit にタグをプッシュ（これで自動化開始！）
 git tag v<version>
 git push origin v<version>
 ```

--- a/docs/homebrew-quickstart.md
+++ b/docs/homebrew-quickstart.md
@@ -50,17 +50,20 @@
 # 1. バージョンを更新（例: 0.2.6）
 vim package.json  # "version": "<version>" に変更
 
-# 2. develop へコミットして main へマージ
+# 2. develop へコミットして main へ PR で統合
 git add package.json CHANGELOG.md
 git commit -m "chore: bump version to <version>"
 git push origin develop
 
+gh pr create --base main --head develop --title "Release v<version>" --body "Release v<version>"
+
+# CI / レビュー / branch protection 通過後
+gh pr merge --merge
+
 git checkout main
 git pull --ff-only origin main
-git merge --no-ff develop
-git push origin main
 
-# 3. main 上でタグをプッシュ
+# 3. main の PR merge commit にタグをプッシュ
 git tag v<version>
 git push origin v<version>
 ```


### PR DESCRIPTION
## Summary
- Sync develop into main after documenting the PR-based release flow.
- This keeps main and develop aligned through the required develop => main PR path.

## Validation
- docs-only change already validated with git diff --check
- direct main merge commands were searched and removed from release docs