### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-02
+
 ### Added
 
 - 最大8アングル・各16ローカルクリップをパッケージ化し、クリップ間の空白を再生時に黒画面と無音で扱う仮想タイムラインを追加

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportaglytics",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Sports video tagging and analytics application",
   "private": true,
   "packageManager": "pnpm@9.1.0",


### PR DESCRIPTION
## Release v0.8.0

- bump package version from 0.7.0 to 0.8.0
- finalize the 2026-08-02 changelog

## Verification
- quality gates passed (66 files / 159 tests)
- production renderer/main/preload builds passed
- preload bundle check passed
- signed x64 and arm64 DMGs generated locally
- codesign deep verification passed for both architectures
- local notarization skipped because notarization options are supplied only in the release environment