### PR TITLE
Prepare release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-02
+
 ### Changed
 
 - メニューバーをドキュメント指向へ再編し、映像パッケージとコードウィンドウの作成・選択を「ファイル > 新規 / 開く」へ集約

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportaglytics",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Sports video tagging and analytics application",
   "private": true,
   "packageManager": "pnpm@9.1.0",


### PR DESCRIPTION
## Release preparation
- bump package version to `0.8.1`
- move the current Unreleased changes into `0.8.1` dated 2026-08-02

## Validation
- all five quality gates passed
- ADR check passed
- production, Electron main, and preload builds passed
- preload bundle check passed
- signed x64 and arm64 apps passed `codesign --verify --deep --strict`
- local x64 and arm64 DMGs generated successfully
- all four Electron E2E suites passed before release preparation

Local notarization was skipped because notarization options were unavailable; the tag-triggered release workflow uses the configured repository secrets.
