### PR TITLE
fix(release): clean stale tag before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,11 @@ jobs:
               exit 1
           fi
 
-      - name: Delete existing release (if exists)
-        continue-on-error: true
+      - name: Delete existing release and tag (if exists)
         run: |
-          gh release delete v${{ steps.get_version.outputs.VERSION }} --yes --cleanup-tag
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          gh release delete "v${VERSION}" --yes --cleanup-tag || true
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/v${VERSION}" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- make the release workflow remove an existing release tag even when no GitHub Release exists
- allow a mistakenly-created `v0.8.3` tag to be replaced by the commit used for the successful release workflow

## Context
`v0.8.3` was created before the 0.8.3 preparation reached `main`. The previous workflow only used `gh release delete --cleanup-tag`, which does not remove a standalone tag when no Release exists. This change explicitly deletes the tag ref before creating the Release.