### PR TITLE
chore(release): trigger corrected 0.8.3 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:
@@ -13,6 +15,10 @@ on:
 
 jobs:
   release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.ref_type == 'tag' ||
+      (github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[release-0.8.3]'))
     runs-on: macos-latest
 
     steps:
@@ -153,6 +159,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.get_version.outputs.VERSION }}
+          target_commitish: ${{ github.sha }}
           files: |
             ./dist/SporTagLytics-${{ steps.get_version.outputs.VERSION }}-arm64.dmg
             ./dist/SporTagLytics-${{ steps.get_version.outputs.VERSION }}-x64.dmg


### PR DESCRIPTION
## Summary
- add a guarded one-shot `main` push trigger for the corrected 0.8.3 release
- pin `target_commitish` to the workflow commit SHA so the recreated `v0.8.3` tag points to the exact `main` release commit

The branch trigger only runs the release job when the main-push commit message contains `[release-0.8.3]`. It will be removed immediately after the release run is started.