### PR TITLE
fix(ci): avoid Vitest EMFILE failures

### DIFF
--- a/.github/workflows/formatting_code.yml
+++ b/.github/workflows/formatting_code.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22.12.0"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -50,4 +50,4 @@ jobs:
         run: pnpm run check:architecture
 
       - name: Test
-        run: pnpm run test:run
+        run: pnpm run test:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           pnpm exec tsc -p electron/tsconfig.json
           pnpm run lint
           pnpm run check:architecture
-          pnpm run test:run
+          pnpm run test:ci
           pnpm run check:adr
 
       - name: Build React app

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build": "vite build",
     "test": "vitest",
     "test:run": "vitest --run",
+    "test:ci": "vitest --run --no-file-parallelism",
     "e2e:prepare": "pnpm run build && pnpm run build:electron-main && pnpm run bundle:preload && pnpm run check:preload",
     "test:e2e": "pnpm run e2e:prepare && node scripts/e2e-clip-sync.mjs && node scripts/e2e-code-window-menu.mjs && node scripts/e2e-export-progress.mjs && node scripts/e2e-timeline-rows.mjs",
     "test:e2e:clip-sync": "pnpm run e2e:prepare && node scripts/e2e-clip-sync.mjs",


### PR DESCRIPTION
## Summary
- add a CI-specific Vitest command that disables file-level parallelism
- use the serialized CI test command in release and PR quality workflows
- align the PR quality workflow with the repository's Node 22.12 minimum

## Why
The 0.8.3 release gate completed 163 tests successfully but failed while loading `@mui/icons-material` with `EMFILE: too many open files`. This is a CI resource-exhaustion failure rather than a test assertion failure.