### PR TITLE
chore(release): retry 0.8.3 after CI stabilization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:
@@ -13,6 +15,10 @@ on:
 
 jobs:
   release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.ref_type == 'tag' ||
+      (github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[release-0.8.3]'))
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
## Summary
- add a guarded one-shot `main` trigger to retry the 0.8.3 release
- run the corrected release workflow after dependency, audit, and Vitest EMFILE fixes

The trigger only executes when the merge commit contains `[release-0.8.3]` and will be removed immediately after the run starts.