### PR TITLE
chore(release): remove one-shot retry trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       version:
@@ -15,10 +13,6 @@ on:
 
 jobs:
   release:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.ref_type == 'tag' ||
-      (github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[release-0.8.3]'))
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
## Summary
- remove the temporary main-push retry trigger for 0.8.3
- restore normal tag/workflow-dispatch release entrypoints
- retain stale-tag cleanup, exact target commit, and serialized CI tests