### PR TITLE
chore(release): retry 0.8.3 after App test isolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:
@@ -13,6 +15,10 @@ on:
 
 jobs:
   release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.ref_type == 'tag' ||
+      (github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[release-0.8.3]'))
     runs-on: macos-latest
 
     steps:
@@ -165,14 +171,9 @@ jobs:
 
       - name: Update Homebrew Tap
         run: |
-          # homebrew-tapリポジトリをクローン
           git clone https://${{ secrets.HOMEBREW_TAP_TOKEN }}@github.com/Kou-ISK/homebrew-tap.git
           cd homebrew-tap
-
-          # Casksディレクトリを作成（初回のみ）
           mkdir -p Casks
-
-          # Cask formulaを生成
           cat > Casks/sportaglytics.rb << 'EOF'
           cask "sportaglytics" do
             version "${{ steps.get_version.outputs.VERSION }}"
@@ -199,8 +200,6 @@ jobs:
             ]
           end
           EOF
-
-          # Git設定とコミット
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/sportaglytics.rb


### PR DESCRIPTION
## Summary
- add a guarded one-shot `main` trigger for the corrected 0.8.3 release
- retry after the App unit-test import boundary fix was verified on `macos-latest`

The temporary trigger only runs when the merge commit contains `[release-0.8.3]` and will be removed immediately after the run starts.