### PR TITLE
fix: 寄り映像の仮想タイムライン再生位置を維持する

### DIFF
--- a/src/features/videoPlayer/components/Controls/VideoController/hooks/useVideoControllerController.ts
+++ b/src/features/videoPlayer/components/Controls/VideoController/hooks/useVideoControllerController.ts
@@ -5,6 +5,7 @@ import { useExistingVideoJsPlayer } from './useExistingVideoJsPlayer';
 import { useVideoControllerControls } from './useVideoControllerControls';
 import type { VideoControllerProps } from '../VideoController.types';
 import { isYoutubeVideoJsPlayer } from '../../../../shared/videojs/videoJsAdapter';
+import { resolveControllerSeekTarget } from '../../../../shared/playbackSyncTiming';
 
 interface VideoControllerToolbarProps {
   hasVideos: boolean;
@@ -112,38 +113,23 @@ export const useVideoControllerController = ({
     const tryPlayAll = () => {
       const basePlayer = getExistingPlayer('video_0');
       const useSlider = !!(
+        !useTimelineClock &&
         syncData?.isAnalyzed &&
         (syncData?.syncOffset ?? 0) < 0 &&
         videoTime < 0
       );
 
-      let baseTime = 0;
-      try {
-        baseTime = useSlider
-          ? videoTime
-          : basePlayer?.currentTime
-            ? basePlayer.currentTime() || videoTime
-            : videoTime;
-      } catch {
-        baseTime = videoTime;
-      }
-
-      let localOffset = 0;
-      if (syncData?.isAnalyzed) {
-        localOffset = syncData.syncOffset || 0;
-      } else if (videoList.length > 1) {
-        const secondaryPlayer = getExistingPlayer('video_1');
-        let secondaryTime = 0;
+      let baseTime = videoTime;
+      if (!useTimelineClock) {
         try {
-          secondaryTime = secondaryPlayer?.currentTime
-            ? secondaryPlayer.currentTime() || 0
-            : 0;
+          baseTime = useSlider
+            ? videoTime
+            : basePlayer?.currentTime
+              ? basePlayer.currentTime() || videoTime
+              : videoTime;
         } catch {
-          secondaryTime = 0;
+          baseTime = videoTime;
         }
-        localOffset =
-          (basePlayer?.currentTime ? basePlayer.currentTime() || 0 : 0) -
-          secondaryTime;
       }
 
       videoList.forEach((_, index) => {
@@ -153,9 +139,35 @@ export const useVideoControllerController = ({
             return;
           }
 
-          const readyState = player.readyState?.() ?? 0;
-          if (index > 0) {
-            const targetTime = Math.max(0, baseTime + localOffset);
+          let localOffset = 0;
+          if (index > 0 && !useTimelineClock) {
+            if (syncData?.isAnalyzed) {
+              localOffset =
+                syncData.angleOffsets?.[index] ?? syncData.syncOffset ?? 0;
+            } else {
+              let secondaryTime = 0;
+              try {
+                secondaryTime = player.currentTime?.() ?? 0;
+              } catch {
+                secondaryTime = 0;
+              }
+
+              let basePlayerTime = baseTime;
+              try {
+                basePlayerTime = basePlayer?.currentTime?.() ?? baseTime;
+              } catch {
+                basePlayerTime = baseTime;
+              }
+              localOffset = basePlayerTime - secondaryTime;
+            }
+          }
+
+          const targetTime = resolveControllerSeekTarget({
+            baseTime,
+            offset: localOffset,
+            useTimelineClock,
+          });
+          if (index > 0 && targetTime !== null) {
             try {
               player.currentTime?.(targetTime);
             } catch {
@@ -174,11 +186,14 @@ export const useVideoControllerController = ({
           };
 
           const delayMs =
-            index > 0 && localOffset > baseTime
-              ? Math.max(0, (localOffset - baseTime) * 1000)
+            index > 0 &&
+            !useTimelineClock &&
+            localOffset < 0 &&
+            baseTime < Math.abs(localOffset)
+              ? Math.max(0, (Math.abs(localOffset) - baseTime) * 1000)
               : 0;
 
-          if (readyState >= 1 || isYoutubeVideoJsPlayer(player)) {
+          if (player.readyState?.() >= 1 || isYoutubeVideoJsPlayer(player)) {
             if (delayMs > 0) {
               globalThis.setTimeout(playNow, delayMs);
             } else {
@@ -188,8 +203,7 @@ export const useVideoControllerController = ({
           }
 
           const onReady = () => {
-            if (index > 0) {
-              const targetTime = Math.max(0, baseTime - localOffset);
+            if (index > 0 && targetTime !== null) {
               try {
                 player.currentTime?.(targetTime);
               } catch {
@@ -221,8 +235,10 @@ export const useVideoControllerController = ({
   }, [
     getExistingPlayer,
     isVideoPlaying,
+    syncData?.angleOffsets,
     syncData?.isAnalyzed,
     syncData?.syncOffset,
+    useTimelineClock,
     videoList,
     videoTime,
   ]);

--- a/src/features/videoPlayer/shared/playbackSyncTiming.test.ts
+++ b/src/features/videoPlayer/shared/playbackSyncTiming.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { resolveControllerSeekTarget } from './playbackSyncTiming';
+
+describe('resolveControllerSeekTarget', () => {
+  it('does not overwrite clip-local player time when the virtual timeline clock is active', () => {
+    expect(
+      resolveControllerSeekTarget({
+        baseTime: 120,
+        offset: 8,
+        useTimelineClock: true,
+      }),
+    ).toBeNull();
+  });
+
+  it('applies the synchronization offset by addition for regular playback', () => {
+    expect(
+      resolveControllerSeekTarget({
+        baseTime: 12,
+        offset: 3,
+        useTimelineClock: false,
+      }),
+    ).toBe(15);
+  });
+
+  it('clamps a negative synchronized target to zero', () => {
+    expect(
+      resolveControllerSeekTarget({
+        baseTime: 2,
+        offset: -5,
+        useTimelineClock: false,
+      }),
+    ).toBe(0);
+  });
+});

--- a/src/features/videoPlayer/shared/playbackSyncTiming.ts
+++ b/src/features/videoPlayer/shared/playbackSyncTiming.ts
@@ -1,0 +1,25 @@
+interface ResolveControllerSeekTargetParams {
+  baseTime: number;
+  offset: number;
+  useTimelineClock: boolean;
+}
+
+/**
+ * Resolve the seek target applied by the shared playback controller.
+ *
+ * Virtual clip timelines already convert the global timeline position into a
+ * clip-local position before mounting each player. Re-seeking those players
+ * with a global time here would corrupt secondary-angle playback, so callers
+ * must leave their currentTime untouched in timeline-clock mode.
+ */
+export const resolveControllerSeekTarget = ({
+  baseTime,
+  offset,
+  useTimelineClock,
+}: ResolveControllerSeekTargetParams): number | null => {
+  if (useTimelineClock) {
+    return null;
+  }
+
+  return Math.max(0, baseTime + offset);
+};


### PR DESCRIPTION
## 原因

仮想クリップタイムラインでは `SyncedVideoPlayer` がグローバル時刻から各クリップのローカル時刻へ変換してプレイヤーを初期化していますが、再生開始後に `VideoController` が `video_1` 以降へグローバル基準の時刻を再設定していました。

そのため `video_0`（引き）は正常でも、`video_1`（寄り）はローカル時刻が上書きされ、誤った位置・終端付近などから再生される可能性がありました。

また通常同期でも、プレイヤーがロード済みかどうかで offset の適用が `+` / `-` と逆転する分岐があり、仕様の `targetTime = globalTime + offset` と一致していませんでした。

## 修正

- 仮想タイムライン時計使用時は、共通コントローラーから各クリップの `currentTime` を上書きしない
- 通常同期では `angleOffsets[index]` を優先し、`syncOffset` を後方互換値として使用
- ロード完了前後で offset の適用を常に加算へ統一
- 負の offset の待機時間を offset 契約に合わせて修正
- 回帰テストを追加

## 検証

純粋関数の回帰テストを追加しています。なお現在の `quality-check` workflow は PR の base が `main` または `feat**` の場合のみ起動する設定で、`develop` 向けPRでは自動CIが起動しません。