### PR TITLE
chore(release): prepare 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-08-15
+
 ### Added
 
 - 映像とタイムラインを独立ウィンドウへ分離し、タイムライン側の編集・シーク・ホットキーを映像側の単一再生状態へ同期

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportaglytics",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Sports video tagging and analytics application",
   "private": true,
   "packageManager": "pnpm@9.1.0",


### PR DESCRIPTION
## Summary

- Set the application version to `0.8.4`.
- Move the completed playback, detached-timeline, and playlist changes into the `0.8.4` changelog section.

## Scope

- In scope: release version and changelog only.
- Out of scope: product-code changes.

## Architecture Impact

- No architecture changes.

## Quality Gate

- [x] TypeScript and Electron TypeScript
- [x] lint / architecture / ADR checks
- [x] 75 test files / 182 tests
- [x] dependency audits
- [x] full Electron E2E
- [x] signed macOS x64 and arm64 package generation

## User Impact / Docs

- [x] `CHANGELOG.md` updated for v0.8.4.